### PR TITLE
Use FROM maven:latest and add mitreid-connect version tag to the image.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.0.4 20160710
+
+* Change to use FROM maven:latest
+* Added a build.sh script that tags the current mitreid-connect version as well as :latest.
+
 ## 0.0.3 20150822
 
 * slimmed image slightly to 1.207 GB by removing double maven build

--- a/Dockerfile.mitreid-connect
+++ b/Dockerfile.mitreid-connect
@@ -2,7 +2,9 @@ FROM maven:latest
 MAINTAINER G. Hussain Chinoy (ghchinoy@gmail.com)
 
 ENV HOME /opt/mitreidc
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/jre
+
+# default to the master (development) branch. Override from docker build --build-arg if you want.
+ARG BRANCH=master
 
 ## Prerequisites: Add user, BouncyCastle
 RUN apt-get update && apt-get upgrade -y && apt-get install -y git wget sudo && apt-get clean && \
@@ -13,16 +15,16 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y git wget sudo && 
 	echo "mitreidc ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
 	chown -R mitreidc:mitreidc $HOME && \
 
-	cd $JAVA_HOME/lib/ext/ && \
+	cd $JAVA_HOME/jre/lib/ext/ && \
 	wget http://downloads.bouncycastle.org/java/bcprov-ext-jdk15on-152.jar -nv && \
-	cd $JAVA_HOME/lib/security && \
-	echo 'security.provider.10=org.bouncycastle.jce.provider.BouncyCastleProvider' >> $JAVA_HOME/lib/security/java.security
+	cd $JAVA_HOME/jre/lib/security && \
+	echo 'security.provider.10=org.bouncycastle.jce.provider.BouncyCastleProvider' >> $JAVA_HOME/jre/lib/security/java.security
 
 # Install
 USER mitreidc
 WORKDIR $HOME
-## get and build
-RUN git clone https://github.com/mitreid-connect/OpenID-Connect-Java-Spring-Server.git . && \
+## get and build the latest production branch
+RUN git clone --branch $BRANCH https://github.com/mitreid-connect/OpenID-Connect-Java-Spring-Server.git . && \
 	mvn -Dmaven.javadoc.skip=true -DskipTests clean install
 WORKDIR $HOME/openid-connect-server-webapp
 # Preload Jetty dependencies

--- a/Dockerfile.mitreid-connect
+++ b/Dockerfile.mitreid-connect
@@ -1,10 +1,10 @@
-FROM java:latest
+FROM maven:latest
 MAINTAINER G. Hussain Chinoy (ghchinoy@gmail.com)
 
 ENV HOME /opt/mitreidc
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/jre
 
-## Prerequisites: Add user, BouncyCastle & Maven 3.3.3
+## Prerequisites: Add user, BouncyCastle
 RUN apt-get update && apt-get upgrade -y && apt-get install -y git wget sudo && apt-get clean && \
 	
 	mkdir -p $HOME && \
@@ -16,13 +16,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y git wget sudo && 
 	cd $JAVA_HOME/lib/ext/ && \
 	wget http://downloads.bouncycastle.org/java/bcprov-ext-jdk15on-152.jar -nv && \
 	cd $JAVA_HOME/lib/security && \
-	echo 'security.provider.10=org.bouncycastle.jce.provider.BouncyCastleProvider' >> $JAVA_HOME/lib/security/java.security && \
-
-	cd /tmp && \
-	wget http://apache-mirror.rbc.ru/pub/apache/maven/maven-3/3.3.3/binaries/apache-maven-3.3.3-bin.tar.gz -nv && \
-	tar -zxf apache-maven-3.3.3-bin.tar.gz -C /tmp/ && \
-	ln -s /tmp/apache-maven-3.3.3/bin/mvn /usr/local/bin/mvn && \
-	rm -rf apache-maven-3.3.3-bin.tar.gz
+	echo 'security.provider.10=org.bouncycastle.jce.provider.BouncyCastleProvider' >> $JAVA_HOME/lib/security/java.security
 
 # Install
 USER mitreidc

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ See the `Dockerfile.mitreid-connect` for more info on how the image was construc
 
 	docker build --tag ghchinoy/mitreid-connect -f Dockerfile.mitreid-connect .
 
+See also build.sh which automatically sets the version tag to the version of mitreid-connect.
+
 ## Notes
 
 * the image is pretty fat, could use some slimming (1.207 GB, thanks maven!)

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+version=`curl -s https://raw.githubusercontent.com/mitreid-connect/OpenID-Connect-Java-Spring-Server/master/pom.xml \
+   | sed -n -e '1,/\<version\>/s~^.*<version>\(.*\)</version>~\1~p'`
+echo Current version of mitreid-connect is $version
+docker build --tag ghchinoy/mitreid-connect:$version --tag ghchinoy/mitreid-connect:latest -f Dockerfile.mitreid-connect .
+
+

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,13 @@
 #!/bin/sh
-version=`curl -s https://raw.githubusercontent.com/mitreid-connect/OpenID-Connect-Java-Spring-Server/master/pom.xml \
+# Usage $0 <branch>
+# For example
+#  ./build.sh master
+#  ./build.sh 1.2.x
+# latest stable branch is 1.2.x; master is the development version.
+BRANCH=${1:-1.2.x}
+version=`curl -s https://raw.githubusercontent.com/mitreid-connect/OpenID-Connect-Java-Spring-Server/$BRANCH/pom.xml \
    | sed -n -e '1,/\<version\>/s~^.*<version>\(.*\)</version>~\1~p'`
 echo Current version of mitreid-connect is $version
-docker build --tag ghchinoy/mitreid-connect:$version --tag ghchinoy/mitreid-connect:latest -f Dockerfile.mitreid-connect .
+docker build --build-arg BRANCH=$BRANCH --tag ghchinoy/mitreid-connect:$version --tag ghchinoy/mitreid-connect:latest -f Dockerfile.mitreid-connect .
 
 


### PR DESCRIPTION
I found your mitreid-connect image quite useful but wanted to get to a current release.
I updated the Dockerfile to use FROM maven:latest and added a simple build.sh script that grabs the current master mitred-connect version and tags the image with that version as well as :latest. I hope you'll consider merging this.

Thanks.
/a
